### PR TITLE
Support string escapes in interpolator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.1"
+ThisBuild / tlBaseVersion := "0.2"
 ThisBuild / organization := "org.polyvariant"
 ThisBuild / organizationName := "Polyvariant"
 ThisBuild / startYear := Some(2022)

--- a/core/shared/src/main/scala/org/polyvariant/colorize.scala
+++ b/core/shared/src/main/scala/org/polyvariant/colorize.scala
@@ -27,11 +27,15 @@ object colorize {
 
   implicit class ColorizeStringContext(private val sc: StringContext) extends AnyVal {
 
-    def colorize(parts: ColorizedString*): ColorizedString =
-      ColorizedString.wrap(sc.parts.head) ++ parts
-        .zip(sc.parts.tail)
+    def colorize(args: ColorizedString*): ColorizedString = {
+      StringContext.checkLengths(args, sc.parts)
+      val partsEscaped = sc.parts.map(StringContext.processEscapes(_))
+
+      ColorizedString.wrap(partsEscaped.head) ++ args
+        .zip(partsEscaped.tail)
         .map { case (p, s) => p ++ ColorizedString.wrap(s) }
         .foldLeft(ColorizedString.empty)(_ ++ _)
+    }
 
   }
 

--- a/core/shared/src/main/scala/org/polyvariant/colorize.scala
+++ b/core/shared/src/main/scala/org/polyvariant/colorize.scala
@@ -28,7 +28,13 @@ object colorize {
   implicit class ColorizeStringContext(private val sc: StringContext) extends AnyVal {
 
     def colorize(args: ColorizedString*): ColorizedString = {
-      StringContext.checkLengths(args, sc.parts)
+      // not available in Scala 2.12 - restore when 2.12 support is dropped
+      // StringContext.checkLengths(args, sc.parts)
+      assert(
+        args.length == sc.parts.length - 1,
+        "Number of arguments must match number of interpolations",
+      )
+
       val partsEscaped = sc.parts.map(StringContext.processEscapes(_))
 
       ColorizedString.wrap(partsEscaped.head) ++ args

--- a/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
+++ b/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
@@ -83,4 +83,25 @@ class ColorizeTests extends munit.FunSuite {
     )
   }
 
+  test("newlines in colorize interpolator") {
+    assertEquals(
+      colorize"\n".render,
+      "\n",
+    )
+  }
+
+  test("newlines in more complex colorize interpolator") {
+    assertEquals(
+      colorize"\n${"aa".overlay("red")}\n${"bb".overlay("blue")}\n".renderConfigured(testConfig),
+      s"\nredaa${R}\nbluebb$R\n",
+    )
+  }
+
+  test("newlines in colorized strings") {
+    assertEquals(
+      "\n".overlay("test").renderConfigured(testConfig),
+      s"test\n$R",
+    )
+  }
+
 }


### PR DESCRIPTION
I wasn't aware of it, but escape sequences aren't actually escaped by default in `sc.parts` - it's up to the interpolator to make that transformation.