### PR TITLE
Add missing `Colorize[String]` instance, add `stripMargin`

### DIFF
--- a/core/shared/src/main/scala/org/polyvariant/colorize/Colorize.scala
+++ b/core/shared/src/main/scala/org/polyvariant/colorize/Colorize.scala
@@ -25,6 +25,7 @@ trait Colorize[A] {
 object Colorize {
   def apply[A](implicit ev: Colorize[A]): Colorize[A] = ev
 
+  implicit val stringColorize: Colorize[String] = ColorizedString.wrap(_)
   implicit val colorizedStringColorize: Colorize[ColorizedString] = identity(_)
 
   /** A reification of the `Colorize` typeclass. If you see a type mismatch saying a

--- a/core/shared/src/main/scala/org/polyvariant/colorize/custom/ConfiguredColorize.scala
+++ b/core/shared/src/main/scala/org/polyvariant/colorize/custom/ConfiguredColorize.scala
@@ -79,6 +79,8 @@ class ConfiguredColorize(config: RenderConfig) {
         case Wrap(s) => currentColors.foldLeft(s)((text, color) => renderColor(color, text))
         case Overlay(underlying, color) => go(underlying, color :: currentColors)
         case Concat(lhs, rhs)           => go(lhs, currentColors) + go(rhs, currentColors)
+        case StripMargin(underlying, char) =>
+          Predef.augmentString(go(underlying, currentColors)).stripMargin(char)
       }
 
     go(s, currentColors = Nil)

--- a/core/shared/src/main/scala/org/polyvariant/colorize/string/ColorizedString.scala
+++ b/core/shared/src/main/scala/org/polyvariant/colorize/string/ColorizedString.scala
@@ -28,6 +28,9 @@ sealed trait ColorizedString extends Product with Serializable {
 
   def ++(another: ColorizedString): ColorizedString = ColorizedString.Concat(this, another)
 
+  def stripMargin: ColorizedString = stripMargin('|')
+  def stripMargin(char: Char): ColorizedString = ColorizedString.StripMargin(this, char)
+
   def overlay(
     newColor: String
   ): ColorizedString = ColorizedString.Overlay(
@@ -58,9 +61,10 @@ sealed trait ColorizedString extends Product with Serializable {
 
   def dropOverlays: ColorizedString =
     this match {
-      case Overlay(underlying, _) => underlying.dropOverlays
-      case w @ Wrap(_)            => w
-      case Concat(lhs, rhs)       => Concat(lhs.dropOverlays, rhs.dropOverlays)
+      case Overlay(underlying, _)        => underlying.dropOverlays
+      case w @ Wrap(_)                   => w
+      case Concat(lhs, rhs)              => Concat(lhs.dropOverlays, rhs.dropOverlays)
+      case StripMargin(underlying, char) => StripMargin(underlying.dropOverlays, char)
     }
 
   def black: ColorizedString = colored(_.BLACK)
@@ -93,6 +97,9 @@ object ColorizedString {
     extends ColorizedString
 
   private[colorize] final case class Concat(lhs: ColorizedString, rhs: ColorizedString)
+    extends ColorizedString
+
+  private[colorize] final case class StripMargin(underlying: ColorizedString, char: Char)
     extends ColorizedString
 
   private[colorize] sealed trait Color extends Product with Serializable

--- a/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
+++ b/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
@@ -74,6 +74,13 @@ class ColorizeTests extends munit.FunSuite {
     )
   }
 
+  test("interpolator: wrap plain string") {
+    assertEquals(
+      colorize"${"s"}".render,
+      "s",
+    )
+  }
+
   test("interpolator: single color") {
     assertEquals(
       colorize"${"aa".overlay("red")}".render,

--- a/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
+++ b/core/shared/src/test/scala/org/polyvariant/colorizetests/ColorizeTests.scala
@@ -141,6 +141,30 @@ class ColorizeTests extends munit.FunSuite {
     )
   }
 
+  test("stripMargin: default") {
+    assertEquals(
+      """hello
+        |world""".overlay("red").stripMargin.render,
+      s"redhello\nworld$R",
+    )
+  }
+
+  test("stripMargin: custom char") {
+    assertEquals(
+      """hello
+        -world""".overlay("red").stripMargin('-').render,
+      s"redhello\nworld$R",
+    )
+  }
+
+  test("double stripMargin") {
+    assertEquals(
+      """hello
+        -|world""".overlay("red").stripMargin('-').stripMargin('|').render,
+      s"redhello\nworld$R",
+    )
+  }
+
   test("default colorize") {
     import org.polyvariant.colorize._
 


### PR DESCRIPTION
After my recent change in #9, the ability to interpolate a string without coloring was removed. I think it should be a thing, so bringing it back.